### PR TITLE
feat: add limit-workspace-range option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ cargo install --git https://github.com/donovanglover/hyprnome --tag 0.2.0
 Usage: hyprnome [OPTIONS]
 
 Options:
-  -p, --previous      Go to the previous workspace instead of the next
-  -m, --move          Move the active window to the dispatched workspace
-  -n, --no-empty      Don't create empty workspaces in the given direction
-  -k, --keep-special  Don't auto-close special workspaces when switching workspaces
-  -c, --cycle         Cycle between workspaces instead of creating new ones
-  -v, --verbose       Print debugging information
-  -h, --help          Print help (see more with '--help')
-  -V, --version       Print version
+  -p, --previous               Go to the previous workspace instead of the next
+  -m, --move                   Move the active window to the dispatched workspace
+  -n, --no-empty               Don't create empty workspaces in the given direction
+  -l, --limit-workspace-range  Only create a max of one empty workspace in a given direction
+  -k, --keep-special           Don't auto-close special workspaces when switching workspaces
+  -c, --cycle                  Cycle between workspaces instead of creating new ones
+  -v, --verbose                Print debugging information
+  -h, --help                   Print help (see more with '--help')
+  -V, --version                Print version
 ```
 
 Example `hyprland.conf`:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,13 @@ struct Cli {
     #[arg(short = 'N', long, default_value_t = false, hide = true)]
     no_empty_after: bool,
 
+    /// Only create a max of one empty workspace in a given direction
+    ///
+    /// This prevents additional empty workspaces from being created if the current active
+    /// workspace is empty and on either end of the workspace list (beginning or end)
+    #[arg(short, long, default_value_t = false)]
+    limit_workspace_range: bool,
+
     /// Don't auto-close special workspaces when switching workspaces
     ///
     /// With --move:
@@ -127,7 +134,7 @@ pub fn log(text: &str) {
 }
 
 /// Gets an ID to dispatch based on the current workspace state and cli options
-pub fn get_options() -> [bool; 7] {
+pub fn get_options() -> [bool; 8] {
     let Cli {
         _move,
         keep_special,
@@ -136,8 +143,9 @@ pub fn get_options() -> [bool; 7] {
         no_empty_before,
         no_empty_after,
         cycle,
+        limit_workspace_range,
         ..
     } = Cli::parse();
 
-    [_move, keep_special, previous, no_empty, no_empty_before, no_empty_after, cycle]
+    [_move, keep_special, previous, no_empty, no_empty_before, no_empty_after, cycle, limit_workspace_range]
 }

--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -5,6 +5,7 @@ use hyprland::data::Workspaces;
 use hyprland::dispatch::{Dispatch, DispatchType, WorkspaceIdentifierWithSpecial};
 use hyprland::prelude::*;
 use hyprnome::WorkspaceState;
+use std::collections::HashMap;
 
 pub fn get_state() -> hyprland::Result<WorkspaceState> {
     let monitors = Monitors::get()?;
@@ -23,9 +24,17 @@ pub fn get_state() -> hyprland::Result<WorkspaceState> {
         .map(|workspace| workspace.id)
         .collect();
 
-    let occupied_ids: Vec<i32> = workspaces.map(|workspace| workspace.id).collect();
+    let occupied_ids: Vec<i32> = workspaces.clone().map(|workspace| workspace.id).collect();
 
-    Ok(WorkspaceState::new(current_id, monitor_ids, occupied_ids))
+    // Create a HashMap to hold the workspace ID and the number of windows
+    let mut workspace_windows: HashMap<i32, u16> = HashMap::new();
+
+    // Populate the HashMap
+    for workspace in workspaces {
+        workspace_windows.insert(workspace.id, workspace.windows);
+    }
+
+    Ok(WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows))
 }
 
 /// Gets whether the current workspace is a special workspace or not.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,15 @@ mod hyprland;
 ///
 /// Specific features are abstracted into lib to make things testable.
 fn main() {
-    let [_move, keep_special, previous, no_empty, no_empty_before, no_empty_after, cycle] = cli::get_options();
+    let [_move, keep_special, previous, no_empty, no_empty_before, no_empty_after, cycle, limit_workspace_range] = cli::get_options();
 
     if let Ok(mut state) = hyprland::get_state() {
         state.set_no_empty_before(no_empty || no_empty_before);
         state.set_no_empty_after(no_empty || no_empty_after);
         state.set_previous(previous);
         state.set_cycle(cycle);
+        state.set_limit_workspace_range(limit_workspace_range);
+        state.set_move(_move);
 
         cli::log(&format!("{state}"));
 

--- a/tests/get_next_id.rs
+++ b/tests/get_next_id.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
+use std::collections::HashMap;
 use hyprnome::WorkspaceState;
 
 #[test]
@@ -7,14 +8,16 @@ fn only_workspace() {
     let current_id = 500;
     let monitor_ids = [500].to_vec();
     let occupied_ids = [500].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 501, "should return next workspace on monitor when only workspace");
 
     let current_id = 498;
     let monitor_ids = [498].to_vec();
     let occupied_ids = [498].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_no_empty_after(true);
 
@@ -26,14 +29,16 @@ fn next_workspace_on_monitor() {
     let current_id = 500;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 502, "should return next workspace on monitor");
 
     let current_id = 500;
     let monitor_ids = [500, 504].to_vec();
     let occupied_ids = [500, 502, 504].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 504, "should return next workspace on monitor with occupied workspaces in-between on other monitors");
 }
@@ -43,14 +48,16 @@ fn next_empty() {
     let current_id = 502;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 503, "should return next empty workspace if last workspace on monitor");
 
     let current_id = 502;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502, 503, 504].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 505, "should return next empty workspace if last workspace on monitor with occupied workspaces on other monitors");
 }
@@ -60,7 +67,8 @@ fn no_empty_after() {
     let current_id = 502;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_no_empty_after(true);
 
@@ -69,7 +77,8 @@ fn no_empty_after() {
     let current_id = 502;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502, 503, 504].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_no_empty_after(true);
 
@@ -81,14 +90,16 @@ fn out_of_bounds() {
     let current_id = i32::MAX;
     let monitor_ids = [500, i32::MAX].to_vec();
     let occupied_ids = [500, i32::MAX].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), i32::MAX, "should return the same workspace if last workspace is i32::MAX");
 
     let current_id = i32::MAX - 2;
     let monitor_ids = [i32::MAX - 2].to_vec();
     let occupied_ids = [i32::MAX - 2, i32::MAX - 1, i32::MAX].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), i32::MAX - 2, "should return the current workspace if all next workspaces are occupied");
 }
@@ -98,14 +109,16 @@ fn fill_the_gaps() {
     let current_id = 4;
     let monitor_ids = [3, 4].to_vec();
     let occupied_ids = [3, 4, 6].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 5, "should return workspace 5 if the occupied workspaces are [3, 4, 6], the monitor workspaces are [3, 4], and the current workspace is 4");
 
     let current_id = 5;
     let monitor_ids = [4, 5].to_vec();
     let occupied_ids = [4, 5, 6, 7, 9].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), 8, "should return workspace 8 if the occupied workspaces are [4, 5, 6, 7, 9], the monitor workspaces are [4, 5], and the current workspace is 5");
 }
@@ -115,14 +128,16 @@ fn returns_the_last_id() {
     let current_id = i32::MAX - 1;
     let monitor_ids = [i32::MAX - 1].to_vec();
     let occupied_ids = [i32::MAX - 1].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), i32::MAX, "should return i32::MAX if it's unoccupied");
 
     let current_id = i32::MAX - 2;
     let monitor_ids = [i32::MAX - 2].to_vec();
     let occupied_ids = [i32::MAX - 2, i32::MAX - 1].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_next_id(), i32::MAX, "should return i32::MAX if it's unoccupied and there are in-between workspaces on other monitors");
 }
@@ -132,9 +147,23 @@ fn cycle() {
     let current_id = 504;
     let monitor_ids = [500, 502, 504].to_vec();
     let occupied_ids = [498, 500, 502, 504, 506].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_cycle(true);
 
     assert_eq!(state.get_next_id(), 500, "should return the first workspace on monitor if last workspace on monitor");
+}
+
+#[test]
+fn limit_workspace_range() {
+    let current_id = 501;
+    let monitor_ids = [500, 501].to_vec();
+    let occupied_ids = [500, 501].to_vec();
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
+
+    state.set_limit_workspace_range(true);
+
+    assert_eq!(state.get_next_id(), 501, "should stay on workspace if it contains no windows");
 }

--- a/tests/get_previous_id.rs
+++ b/tests/get_previous_id.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
+use std::collections::HashMap;
 use hyprnome::WorkspaceState;
 
 #[test]
@@ -7,14 +8,16 @@ fn only_workspace() {
     let current_id = 500;
     let monitor_ids = [500].to_vec();
     let occupied_ids = [500].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 499, "should return previous workspace on monitor when only workspace");
 
     let current_id = 500;
     let monitor_ids = [500].to_vec();
     let occupied_ids = [500].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_no_empty_before(true);
 
@@ -26,14 +29,16 @@ fn previous_workspace_on_monitor() {
     let current_id = 502;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 500, "should return previous workspace on monitor");
 
     let current_id = 504;
     let monitor_ids = [500, 504].to_vec();
     let occupied_ids = [500, 502, 504].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 500, "should return previous workspace on monitor with occupied workspaces in-between on other monitors");
 }
@@ -43,14 +48,16 @@ fn previous_empty() {
     let current_id = 500;
     let monitor_ids = [500, 501].to_vec();
     let occupied_ids = [500, 501].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 499, "should return previous empty workspace if first workspace on monitor");
 
     let current_id = 500;
     let monitor_ids = [500, 501].to_vec();
     let occupied_ids = [499, 500, 501].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 498, "should return previous empty workspace if first workspace on monitor with occupied workspaces on other monitors");
 }
@@ -60,7 +67,8 @@ fn no_empty_before() {
     let current_id = 500;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [500, 502].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_no_empty_before(true);
 
@@ -69,7 +77,8 @@ fn no_empty_before() {
     let current_id = 500;
     let monitor_ids = [500, 502].to_vec();
     let occupied_ids = [498, 499, 500, 502].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_no_empty_before(true);
 
@@ -81,14 +90,16 @@ fn out_of_bounds() {
     let current_id = 1;
     let monitor_ids = [1, 2].to_vec();
     let occupied_ids = [1, 2].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 1, "should return the same workspace if first workspace is 1");
 
     let current_id = 3;
     let monitor_ids = [3, 4].to_vec();
     let occupied_ids = [1, 2, 3, 4].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 3, "should return the current workspace if all previous workspaces are occupied");
 }
@@ -98,14 +109,16 @@ fn fill_the_gaps() {
     let current_id = 3;
     let monitor_ids = [3, 4].to_vec();
     let occupied_ids = [1, 3, 4].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 2, "should return workspace 2 if the occupied workspaces are [1, 3, 4], the monitor workspaces are [3, 4], and the current workspace is 3");
 
     let current_id = 4;
     let monitor_ids = [4, 5].to_vec();
     let occupied_ids = [1, 3, 4, 5].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 2, "should return workspace 2 if the occupied workspaces are [1, 3, 4, 5], the monitor workspaces are [4, 5], and the current workspace is 4");
 }
@@ -115,14 +128,16 @@ fn returns_the_first_id() {
     let current_id = 2;
     let monitor_ids = [2, 3].to_vec();
     let occupied_ids = [2, 3].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 1, "should return 1 if it's unoccupied");
 
     let current_id = 4;
     let monitor_ids = [4, 5].to_vec();
     let occupied_ids = [2, 3, 4, 5].to_vec();
-    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     assert_eq!(state.get_previous_id(), 1, "should return 1 if it's unoccupied and there are in-between workspaces on other monitors");
 }
@@ -132,9 +147,23 @@ fn cycle() {
     let current_id = 500;
     let monitor_ids = [500, 502, 504].to_vec();
     let occupied_ids = [498, 500, 502, 504].to_vec();
-    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids);
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
 
     state.set_cycle(true);
 
     assert_eq!(state.get_previous_id(), 504, "should return the last workspace on monitor if first workspace on monitor");
+}
+
+#[test]
+fn limit_workspace_range() {
+    let current_id = 501;
+    let monitor_ids = [500, 501].to_vec();
+    let occupied_ids = [500, 501].to_vec();
+    let workspace_windows: HashMap<i32, u16> = occupied_ids.iter().map(|&key| (key, 0 as u16)).collect();
+    let mut state = WorkspaceState::new(current_id, monitor_ids, occupied_ids, workspace_windows);
+
+    state.set_limit_workspace_range(true);
+
+    assert_eq!(state.get_previous_id(), 500, "should stay on workspace if it contains no windows");
 }


### PR DESCRIPTION
## Description of changes

This adds the ability to restrict workspace creation to one workspace outside the non-empty workspaces. It also stops one from moving a window into an empty workspace when there is only one window in the workspace. This prevents the creation of 'pointless' workspaces.

This reduces the range of movement in terms of workspace ID's, lowering the chance of potentially overlapping ID's for multiple monitors. The main reason I like this feature, however, is that my waybar gives weird animations when switching from empty workspace to empty workspace on the end, or moving a singular window to a new workspace. 

You could say just stop switching forward or backward once you get a new workspace, but I'd like to be able to mash the button to get all the way to the new workspace without overshooting it.

I'd like to note that I send the `--move` param value to the `WorkspaceState` and access it in `get_*_id`. This doesn't seem too optimal to me. If you can see a better way to execute this, let me know!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Formatted code with `cargo fmt`
- [x] Checked for linting issues with `cargo clippy`
- [x] Tested that the binary works as expected with `cargo build`
- [x] Ran software tests with `cargo test`
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/donovanglover/hyprnome/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
